### PR TITLE
Feature/recursive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,5 @@ collect:
 	@( \
        source ./.pyenv/bin/activate; \
 	./run.sh --dry=$(dry) --depth=$(depth) --email="$(email)" --upload=$(upload) $(folder) ; \
+	exit 0 ; \
 	)
-	@exit 0

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,11 @@ install: install_requirements help
 
 dry:=0
 depth:=1
+upload:='default'
 folder:=$(filter-out $@,$(MAKECMDGOALS))
 collect: 
 	@( \
        source ./.pyenv/bin/activate; \
-	./run.sh --dry=$(dry) --depth=$(depth) --email="$(email)" $(folder) ; \
+	./run.sh --dry=$(dry) --depth=$(depth) --email="$(email)" --upload=$(upload) $(folder) ; \
 	)
 	@exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,71 @@
+SHELL = /usr/bin/env bash
+
+YELLOW=\033[0;33m
+RED=\033[0;31m
+WHITE=\033[0m
+GREEN=\u001B[32m
+CYAN=
+
+PYTHON3_EXECUTABLE := $(shell command -v python3 2> /dev/null)
+PIP3_EXECUTABLE := $(shell command -v pip3 2> /dev/null)
+
 .PHONY: test
 test:
 	nose2
 docker:
 	docker build -t codersrank/repo_info_extractor:latest .
+
+
+install_pip:
+	@if [ "$(PYTHON3_EXECUTABLE)" != "" ]; then \
+		echo -e "Found $(GREEN)python3$(WHITE)" ;\
+		sudo apt install -y -q python3-venv ;\
+		wait ;\
+		if [ "$(PIP3_EXECUTABLE)" != "" ]; then \
+			echo -e "Upgrading to latest $(GREEN)pip$(WHITE)" ;\
+			pip3 install --upgrade 'pip>=9.0.1' ;\
+			wait ;\
+		else \
+			if [ -f "get-pip.py" ]; then \
+			echo -e "Downloading latest $(GREEN)pip$(WHITE)" ;\
+			wget https://bootstrap.pypa.io/get-pip.py ; \
+			fi ;\
+			python3 get-pip.py --user ;\
+			wait ;\
+		fi ;\
+		wait ;\
+		rm -rf ./.pyenv ;\
+		python3 -m venv ./.pyenv ;\
+	else \
+		echo -e "Oops it seems python3 isn't installed" ;\
+		echo -e "Run $(GREEN)sudo apt install python3$(WHITE)" ;\
+		echo -e " AND THEN $(GREEN)make install$(WHITE)" ;\
+		exit 0 ;\
+	fi
+
+install_requirements: install_pip
+	@( \
+       source ./.pyenv/bin/activate; \
+       pip3 install --upgrade 'pip>=9.0.1' ; \
+       pip3 install -r requirements.txt; \
+    )
+
+help:
+	@./run.sh -h
+
+install: install_requirements help
+
+
+%:  
+	@:
+
+
+dry:=0
+depth:=1
+folder:=$(filter-out $@,$(MAKECMDGOALS))
+collect: 
+	@( \
+       source ./.pyenv/bin/activate; \
+	./run.sh --dry=$(dry) --depth=$(depth) --email="$(email)" $(folder) ; \
+	)
+	@exit 0

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,127 @@
 #!/usr/bin/env bash
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
+BLUE=`tput setaf 4`
+PURPLE=`tput setaf 5`
+CYAN=`tput setaf 6`
+BRIGHT=`tput setaf 7`
 
-python src/main.py "$@"
+BRED=`tput bold && tput setaf 1`
+BGREEN=`tput bold && tput setaf 2`
+BYELLOW=`tput bold && tput setaf 3`
+BBLUE=`tput bold && tput setaf 4`
+BPURPLE=`tput bold && tput setaf 5`
+BCYAN=`tput bold && tput setaf 6`
+BBRIGHT=`tput bold && tput setaf 7`
+
+RESET=`tput sgr0`
+exitfn () {
+    trap SIGINT              
+    echo; echo 'Interrupted by user!!'
+    exit                     
+}
+red() {
+  return "${RED}$1${WHITE}"
+}
+
+trap "exitfn" INT
+local_projects() {
+  repos=`find $folder -maxdepth $depth  -type d  -wholename "*/.git" -exec dirname {} \;`
+  number_of_repos=`echo $repos | wc -w`
+  skip_upload=''
+
+	if [ "$number_of_repos" > 1 ]; then
+    skip_upload='--skip_upload 1'
+  fi
+
+  for REPO_PATH in $repos
+  do
+    rm -rf 1
+	  REPO_NAME=`echo $REPO_PATH | sed -e 's/\/$//g' | rev | cut -d'/' -f 1 | rev `  >&2;
+    FILE_NAME="./"$REPO_NAME".json"
+	  if [ "$dry_run" != 0 ]; then
+      echo "found repo ${BGREEN}$REPO_NAME${RESET}"
+    else
+      echo "repo ${BGREEN}$REPO_NAME${RESET} will be saved as ${BCYAN}$FILE_NAME${RESET}"
+      python src/main.py "$REPO_PATH" --output $FILE_NAME --default_email "$email" $skip_upload && wait
+	  fi
+	  echo " "
+  done;
+
+}
+
+#python src/main.py "$REPO_PATH" --output $FILE_NAME
+
+
+depth=1
+dry_run=0
+folder="${!#}"
+paramnum=$#
+email=""
+optspec=":h-:"
+while getopts "$optspec" optchar; do
+     case "${optchar}" in
+        -)
+            case "${OPTARG}" in
+                dry=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    if [ "$val" != "0" ]; then
+                      echo "${BCYAN}Dry run${RESET}, will only list repos"
+                    fi
+                    dry_run=$val
+                    ;;
+                depth=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    depth=$val
+                    ;;
+                email=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    email=$val
+                    if [ "$val" != "" ]; then
+                      echo "Commits from ${BCYAN}${email}${RESET}, will be preselected" >&2
+                    fi
+                    ;;
+                *)
+                    if [ "$OPTERR" = 1 ] && [ "${optspec:0:1}" != ":" ]; then
+                        echo "Unknown option --${OPTARG}" >&2
+                    fi
+                    ;;
+            esac;;
+        h)
+            echo -e ""
+            echo -e "collect your repos info using: "
+            echo -e ""
+            echo -e "    ${GREEN}make collect${RESET} ${BCYAN}<folder>${RESET} ${BBRIGHT}[depth=<depth>] [dry=0|1] [email=user@domain.com]${RESET}"
+            echo -e ""
+            echo -e "Examples:"
+            echo -e "  ${GREEN}fab help${RESET}                                  display this help message"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET}                     get info of ${BCYAN}my_repo${RESET}"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}email=me@mail.com${RESET}    same as above, but preselect ${BCYAN}me@mail.com${RESET} in author list"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} ${BBRIGHT}depth=2${RESET}             get info every repo under ${BCYAN}~/projects${RESET} until a given depth"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}dry=1${RESET}                just display repos that will be examined"
+            echo -e ""
+            echo -e "Combine them all"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} depth=2 dry=1 email=me@mail.com "
+            exit 0
+            ;;
+       
+            
+      
+        *)
+            if [ "$OPTERR" != 1 ] || [ "${optspec:0:1}" = ":" ]; then
+                echo "Non-option argument: '-${OPTARG}'" >&2
+            fi
+            ;;
+    esac
+done 
+
+  echo "Search repos on ${BPURPLE}$folder${RESET}, ${BCYAN}$depth${RESET} folders deep"
+  local_projects
+  echo "Finished"
+  
+trap SIGINT
+exit 0

--- a/run.sh
+++ b/run.sh
@@ -29,11 +29,6 @@ trap "exitfn" INT
 local_projects() {
   repos=`find $folder -maxdepth $depth  -type d  -wholename "*/.git" -exec dirname {} \;`
   number_of_repos=`echo $repos | wc -w`
-  skip_upload=''
-
-	if [ "$number_of_repos" > 1 ]; then
-    skip_upload='--skip_upload 1'
-  fi
 
   for REPO_PATH in $repos
   do
@@ -44,7 +39,7 @@ local_projects() {
       echo "found repo ${BGREEN}$REPO_NAME${RESET}"
     else
       echo "repo ${BGREEN}$REPO_NAME${RESET} will be saved as ${BCYAN}$FILE_NAME${RESET}"
-      python src/main.py "$REPO_PATH" --output $FILE_NAME --default_email "$email" $skip_upload && wait
+      python src/main.py "$REPO_PATH" --output $FILE_NAME --default_email "$email" --upload $upload && wait
 	  fi
 	  echo " "
   done;
@@ -59,6 +54,7 @@ dry_run=0
 folder="${!#}"
 paramnum=$#
 email=""
+upload='default'
 optspec=":h-:"
 while getopts "$optspec" optchar; do
      case "${optchar}" in
@@ -76,6 +72,11 @@ while getopts "$optspec" optchar; do
                     val=${OPTARG#*=}
                     opt=${OPTARG%=$val}
                     depth=$val
+                    ;;
+                upload=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    upload=$val
                     ;;
                 email=*)
                     val=${OPTARG#*=}
@@ -95,17 +96,19 @@ while getopts "$optspec" optchar; do
             echo -e ""
             echo -e "collect your repos info using: "
             echo -e ""
-            echo -e "    ${GREEN}make collect${RESET} ${BCYAN}<folder>${RESET} ${BBRIGHT}[depth=<depth>] [dry=0|1] [email=user@domain.com]${RESET}"
+            echo -e "    ${GREEN}make collect${RESET} ${BCYAN}<folder>${RESET} ${BBRIGHT}[depth=<depth>] [dry=0|1] [email=user@domain.com] [upload=skip]${RESET}"
             echo -e ""
             echo -e "Examples:"
-            echo -e "  ${GREEN}fab help${RESET}                                  display this help message"
+            echo -e "  ${GREEN}make help${RESET}                                  display this help message"
             echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET}                     get info of ${BCYAN}my_repo${RESET}"
-            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}email=me@mail.com${RESET}    same as above, but preselect ${BCYAN}me@mail.com${RESET} in author list"
-            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} ${BBRIGHT}depth=2${RESET}             get info every repo under ${BCYAN}~/projects${RESET} until a given depth"
-            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}dry=1${RESET}                just display repos that will be examined"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}email=me@mail.com${RESET}   same as above, but preselect ${BCYAN}me@mail.com${RESET} in author list"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} ${BBRIGHT}depth=2${RESET}            get info every repo under ${BCYAN}~/projects${RESET} until a given depth"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}dry=1${RESET}               just display repos that will be examined"
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/my_repo${RESET} ${BBRIGHT}upload=skip${RESET}         skip auto upload prompt"
             echo -e ""
             echo -e "Combine them all"
-            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} depth=2 dry=1 email=me@mail.com "
+            echo -e "  ${GREEN}make collect${RESET} ${BCYAN}~/projects${RESET} depth=2 dry=1 email=me@mail.com upload=skip"
+            echo ""
             exit 0
             ;;
        

--- a/src/export_result.py
+++ b/src/export_result.py
@@ -10,12 +10,14 @@ class ExportResult:
     def __init__(self, data):
         self.data = data
 
-    def export_to_json_interactive(self, file_name):
+    def export_to_json_interactive(self, file_name, skip_upload=False):
         self.dump(file_name)
 
         q = Questions()
-
-        result = q.query_yes_no(
+        if skip_upload:
+            result = False
+        else 
+            result = q.query_yes_no(
             'Do you want to upload the result to your profile automatically?')
         if result:
             response = uploadRepo(file_name + '.zip')

--- a/src/export_result.py
+++ b/src/export_result.py
@@ -10,13 +10,13 @@ class ExportResult:
     def __init__(self, data):
         self.data = data
 
-    def export_to_json_interactive(self, file_name, skip_upload=False):
+    def export_to_json_interactive(self, file_name, upload='default'):
         self.dump(file_name)
 
         q = Questions()
-        if skip_upload:
+        if upload == 'skip':
             result = False
-        else 
+        else:
             result = q.query_yes_no(
             'Do you want to upload the result to your profile automatically?')
         if result:

--- a/src/init.py
+++ b/src/init.py
@@ -8,7 +8,7 @@ from ui.questions import Questions
 from obfuscator import obfuscate
 
 
-def initialize(directory, skip_obfuscation, output, parse_libraries, default_email, skip_upload):
+def initialize(directory, skip_obfuscation, output, parse_libraries, default_email, upload):
     repo = git.Repo(directory)
     ar = AnalyzeRepo(repo)
     q = Questions()
@@ -41,7 +41,7 @@ def initialize(directory, skip_obfuscation, output, parse_libraries, default_ema
         # In case the repo is empty don't show the question
         if len(authors) != 0:
             identities_err = None
-            identities = q.ask_user_identity(authors, identities_err)
+            identities = q.ask_user_identity(authors, identities_err, default_email)
             MAX_LIMIT = 50
             while len(identities['user_identity']) == 0 or len(identities['user_identity']) > MAX_LIMIT:
                 if len(identities['user_identity']) == 0:
@@ -67,7 +67,7 @@ def initialize(directory, skip_obfuscation, output, parse_libraries, default_ema
             r = obfuscate(r)
 
         er = ExportResult(r)
-        er.export_to_json_interactive(output, skip_upload)
+        er.export_to_json_interactive(output, upload)
 
     except KeyboardInterrupt:
         print ("Shutdown requested...exiting")

--- a/src/init.py
+++ b/src/init.py
@@ -13,7 +13,7 @@ def initialize(directory, skip_obfuscation, output, parse_libraries, default_ema
     ar = AnalyzeRepo(repo)
     q = Questions()
 
-    print('Initialization...')
+    print('Analyzing repo under %s ...' % (directory))
     try:
         if not repo.branches:
             print('No branches detected, will ignore this repo')

--- a/src/main.py
+++ b/src/main.py
@@ -13,11 +13,11 @@ def main():
                         dest='parse_libraries', help='If true, used libraries will be parsed')
     parser.add_argument('--default_email', default='',
                         dest='default_email', help='If set, commits from this email are preselected on authors list')
-    parser.add_argument('--skip_upload', default=False,
-                        dest='skip_upload', help='If true, skip the prompt to upload automatically')
-
+    parser.add_argument('--upload', default='default',
+                        dest='upload', help='If set to "skip", skip the prompt to upload automatically')
     args = parser.parse_args()
-    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.default_email, args.skip_upload)
+    print(args.default_email)
+    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.default_email, args.upload)
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,9 @@
 import argparse
 from init import initialize
+from pprint import pprint
+from os import *
+from ui.questions import Questions
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -13,12 +17,27 @@ def main():
                         dest='parse_libraries', help='If true, used libraries will be parsed')
     parser.add_argument('--default_email', default='',
                         dest='default_email', help='If set, commits from this email are preselected on authors list')
-    parser.add_argument('--upload', default='default',
-                        dest='upload', help='If set to "skip", skip the prompt to upload automatically')
-    args = parser.parse_args()
-    print(args.default_email)
-    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.default_email, args.upload)
+    parser.add_argument('--upload', default='defaul',
+                        dest='upload', help="If set to 'skip', don't prompt for automatic upload")
+    try:
+        args = parser.parse_args()
+        
+        folders=args.directory.split('|,|')
+        if len(folders) > 1:
+            q = Questions()
+            repos = q.ask_which_repos(folders)
+            if len(repos['chosen_repos']) > 0:
+                for repo in repos['chosen_repos']:
+                    output=('./%s.json' % (path.basename(repo).replace(' ','_')))
+                    initialize(repo, args.skip_obfuscation, output, args.parse_libraries, args.default_email, args.upload)
+        else:
+            initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.default_email, args.upload)
 
+    except KeyboardInterrupt:
+        print ("Shutdown requested...exiting")
+        os._exit(0)
+    except Exception:
+        os._exit(1)
 
 if __name__ == "__main__":
     import multiprocessing

--- a/src/main.py
+++ b/src/main.py
@@ -11,9 +11,13 @@ def main():
                         help='If true it won\'t obfuscate the sensitive data such as emails and file names. Mostly for testing purpuse')
     parser.add_argument('--parse_libraries', default=False,
                         dest='parse_libraries', help='If true, used libraries will be parsed')
+    parser.add_argument('--default_email', default='',
+                        dest='default_email', help='If set, commits from this email are preselected on authors list')
+    parser.add_argument('--skip_upload', default=False,
+                        dest='skip_upload', help='If true, skip the prompt to upload automatically')
 
     args = parser.parse_args()
-    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries)
+    initialize(args.directory, args.skip_obfuscation, args.output, args.parse_libraries, args.default_email, args.skip_upload)
 
 
 if __name__ == "__main__":

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -47,6 +47,27 @@ class Questions:
 
         return prompt(questions)
 
+    def ask_which_repos(self, repos):
+        choices = []
+        for repo in repos:
+            choices.append({
+                'name': repo
+            })
+            
+        message = 'The following repos where found in the given path. \
+            Select which ones you want to analyze (With SPACE you can select more than one)'
+        
+        questions = [
+            {
+                'type': 'checkbox',
+                'name': 'chosen_repos',
+                'message': message,
+                'choices': choices
+            }
+        ]
+
+        return prompt(questions)
+
     def query_yes_no(self, question, default="yes"):
         """Ask a yes/no question via raw_input() and return their answer.
 

--- a/src/ui/questions.py
+++ b/src/ui/questions.py
@@ -22,13 +22,15 @@ class Questions:
 
         return prompt(questions)
 
-    def ask_user_identity(self, authors, err):
+    def ask_user_identity(self, authors, err, default_email=''):
         choices = []
         for name, email in authors:
+            checked = email == default_email
             choices.append({
                 'name': name + ' -> ' + email,
+                'checked': checked
             })
-
+            
         message = 'The following contributors were found in the repository. \
             Select which ones you are. (With SPACE you can select more than one)'
         if err:


### PR DESCRIPTION
Adds a few enhancements to use the extractor
(assuming there is Python 3.x + bash + Makefile)

-  Point to a folder containing several repos, and pass `depth` parameter to search recursively 

```bash
./run.sh  --depth=2 ~/projects 
```
![recursive_search gif](https://user-images.githubusercontent.com/238439/66866299-610a8b00-ef6f-11e9-96bd-75200f1df00d.gif)

(when using the `depth` option the value of `output` is ignored and replaced with the folder name of each repo. This could be enhanced soon to instead create a folder named after the `output` parameter)

________________
- You can pass default email to preselect matching authors

```bash
./run.sh  --email=amenadiel@mail.com ~/projects/repo
```

![preselect_emails2](https://user-images.githubusercontent.com/238439/66866430-a7f88080-ef6f-11e9-9647-1213a01bd8ed.gif)

________________
- Can skip auto upload prompt (if extracting several repos, you know...)

```bash
./run.sh  --upload=skip ~/projects/repo
```
![skip_upload](https://user-images.githubusercontent.com/238439/66866500-cf4f4d80-ef6f-11e9-8257-70d0b6d8d790.gif)


________________________
 - Exception handling and exit early on edge cases
   - no branches
   - no commits
   - no authors
   - keyboard interrupt

_______________

- Everything runs on a virtualenv

 - `make install` installs python-venv and creates virtualenv (given you have python3) to avoid issues with versions and permissions
 - `./run.sh` activates the virtualenv when invoking src/main.py

![virtualenv](https://user-images.githubusercontent.com/238439/66867519-dc6d3c00-ef71-11e9-90da-eaa72dc286d9.gif)

(I didn't made the port for python2. I won't either)

